### PR TITLE
Saga can be created at given time

### DIFF
--- a/src/Saga.php
+++ b/src/Saga.php
@@ -92,12 +92,15 @@ abstract class Saga
      * @throws \ServiceBus\Sagas\Exceptions\InvalidSagaIdentifier
      * @throws \ServiceBus\Common\Exceptions\DateTimeException
      */
-    final public function __construct(SagaId $id, ?\DateTimeImmutable $expireDate = null)
-    {
+    final public function __construct(
+        SagaId $id,
+        ?\DateTimeImmutable $expireDate = null,
+        ?\DateTimeImmutable $createdAt = null
+    ) {
         $this->assertSagaClassEqualsWithId($id);
         $this->clear();
 
-        $currentDatetime = now();
+        $createdAt = $createdAt ?? now();
 
         /** @var \DateTimeImmutable $expireDate */
         $expireDate = $expireDate ?? datetimeInstantiator(SagaMetadata::DEFAULT_EXPIRE_INTERVAL);
@@ -107,11 +110,11 @@ abstract class Saga
         $this->id     = $id;
         $this->status = SagaStatus::created();
 
-        $this->createdAt  = $currentDatetime;
+        $this->createdAt  = $createdAt;
         $this->expireDate = $expireDate;
 
         /** @noinspection PhpUnhandledExceptionInspection */
-        $this->raise(new SagaCreated($id, $currentDatetime, $expireDate));
+        $this->raise(new SagaCreated($id, $createdAt, $expireDate));
     }
 
     /**

--- a/tests/SagaTest.php
+++ b/tests/SagaTest.php
@@ -200,6 +200,25 @@ class SagaTest extends TestCase
      *
      * @throws \Throwable
      */
+    public function sagaCanBeCreatedAtGivenTime(): void
+    {
+        $id                 = new TestSagaId('123456789', CorrectSaga::class);
+        $createdAt          = datetimeInstantiator('2012-12-12');
+        $nonsenseExpireDate = datetimeInstantiator('+4543 days');
+        $saga               = new CorrectSaga($id, $nonsenseExpireDate, $createdAt);
+        $saga->start(new EmptyCommand());
+
+        /** @var array<int, string> $events */
+        $events = invokeReflectionMethod($saga, 'raisedEvents');
+
+        static::assertEquals([new SagaCreated($id, $createdAt, $nonsenseExpireDate)], $events);
+    }
+
+    /**
+     * @test
+     *
+     * @throws \Throwable
+     */
     public function makeFailed(): void
     {
         $id   = new TestSagaId('123456789', CorrectSaga::class);


### PR DESCRIPTION
This PR gives possibility to specify creation date of the saga.
It removes dependency from current time and gives possibility to write tests for sagas in convenient way (we can assert whole emitted messages instead of field by field message assertions) and in the same time do not use magic like reflection etc for access private state.